### PR TITLE
Migrate createBrowserRouter --> BrowserRouter

### DIFF
--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -1,39 +1,33 @@
-import { createBrowserRouter, createRoutesFromElements, RouterProvider, Route } from "react-router-dom"
+import { createBrowserRouter, createRoutesFromElements, BrowserRouter, Routes, RouterProvider, Route } from "react-router-dom"
 import { Root } from "./components/router"
 import loaders from "./loaders"
 import Header from "./components/header/header"
+import Footer from "./components/footer/footer"
 import HomePage from "./pages/Home/home"
 import ProjectPage from "./pages/Projects/Projects"
 import Login from "./pages/Login/login"
 import PrivateRoutes from "./context/privateRoute"
+import AuthProvider from "./context/authContext"
 
 
-function Router ({children}) {
-
-    const router = createBrowserRouter(
-        createRoutesFromElements(
-            <Route path="/" element={<Root />}>
-                <Route element={<PrivateRoutes/>}>
-                    <Route 
-                        path="home" 
-                        element={<HomePage />}
-                    />
-                    <Route 
-                        path="projects" 
-                        element={<ProjectPage />}
-                        loader={loaders.projects}
-                    />
-                </Route>
-                <Route path="login" element={<Login/>}/>
-            </Route>
-        )
-    ) 
-
-    return <RouterProvider router={router}>{children}</RouterProvider>
-
+function Router () {
     
-
-
+    return (
+        <BrowserRouter>
+            <AuthProvider>
+                <Header />
+                <Routes>
+                    <Route path="/login" element={<Login/>}/>
+                    {/* <Route path="/signup" element={<Signup/>}/> */}
+                    <Route element={<PrivateRoutes/>}>
+                        <Route path="/home" element={<HomePage/>}/>
+                        <Route path="/projects" element={<ProjectPage/>}/>
+                    </Route>
+                </Routes>
+                <Footer />
+            </AuthProvider>
+        </BrowserRouter>
+    )
 }
 
 export default Router

--- a/src/context/authContext.jsx
+++ b/src/context/authContext.jsx
@@ -55,6 +55,7 @@ function AuthProvider ({ children }) {
                 setLoading(false)
                 return { data : data, status : request.status }
             }
+            navigate('/home')
             setUser(data)
             setLoading(false)
         } catch (error) {
@@ -72,7 +73,7 @@ function AuthProvider ({ children }) {
     }
 
     return <AuthContext.Provider value={context}>
-        { loading ? <Spinner/> : <Outlet/> }
+        { loading ? <Spinner/> : children }
     </AuthContext.Provider>
 }
 


### PR DESCRIPTION
I initially wanted to use the new data loaders that are available in react router dom's new 6.4+ routers, but it was difficult to find ways to work with loaders in the way I wanted. 

Decided to just stick with BrowserRouter for this project instead 